### PR TITLE
Fix a bug in internalLockLoop(), where startTime is never updated.

### DIFF
--- a/recipes/locks.go
+++ b/recipes/locks.go
@@ -278,7 +278,9 @@ func (l *lockInternals) internalLockLoop(startTime time.Time, waitTime time.Dura
 
 				c := make(chan error)
 
-				t := time.NewTimer(waitTime - time.Now().Sub(startTime))
+				now := time.Now()
+				t := time.NewTimer(waitTime - now.Sub(startTime))
+				startTime = now
 
 				l.client.GetData().UsingWatcher(curator.NewWatcher(func(event *zk.Event) {
 					c <- event.Err


### PR DESCRIPTION
In Java version of curator:
```Java
if ( millisToWait != null )
    {
         millisToWait -= (System.currentTimeMillis() - startMillis);
        // start time is updated here
        startMillis = System.currentTimeMillis();
        if ( millisToWait <= 0 )
         {
             doDelete = true;    // timed out - delete our node
             break;
          }
           wait(millisToWait);
     }
```